### PR TITLE
登録フォルダの削除動作を設定ページ上で行うよう変更 #102

### DIFF
--- a/TsubameViewer.Core/Models/SourceFolders/SourceStorageItemIgnoringRequestMessage.cs
+++ b/TsubameViewer.Core/Models/SourceFolders/SourceStorageItemIgnoringRequestMessage.cs
@@ -5,11 +5,17 @@ using System.Text;
 
 namespace TsubameViewer.Core.Models.SourceFolders;
 
-public class SourceStorageItemIgnoringRequestMessage : ValueChangedMessage<string>
+public class SourceStorageItemIgnoringRequestMessage : AsyncRequestMessage<StorageItemDeletionResult>
 {
-    public SourceStorageItemIgnoringRequestMessage(string value) : base(value)
+    public SourceStorageItemIgnoringRequestMessage(string path)
     {
+        Path = path;
     }
+
+    public string Path { get; }
 }
 
-
+public class StorageItemDeletionResult
+{
+    
+}

--- a/TsubameViewer.Core/Models/SourceFolders/SourceStorageItemsRepository.cs
+++ b/TsubameViewer.Core/Models/SourceFolders/SourceStorageItemsRepository.cs
@@ -243,7 +243,7 @@ public sealed class SourceStorageItemsRepository
     }
 
 
-    public async IAsyncEnumerable<string> GetDescendantItemPathsAsync(string parentPath)
+    public async IAsyncEnumerable<string> GetDescendantItemPathsAsync(string parentPath, bool withMostRecentlyUsed = false)
     {
         foreach (var entry in StorageApplicationPermissions.FutureAccessList.Entries)
         {
@@ -253,13 +253,16 @@ public sealed class SourceStorageItemsRepository
                 yield return item.Path;
             }
         }
-
-        foreach (var entry in StorageApplicationPermissions.MostRecentlyUsedList.Entries)
+        
+        if (withMostRecentlyUsed)
         {
-            var item = await StorageApplicationPermissions.MostRecentlyUsedList.GetItemAsync(entry.Token, AccessCacheOptions.FastLocationsOnly);
-            if (parentPath != item.Path && item.Path.StartsWith(parentPath))
+            foreach (var entry in StorageApplicationPermissions.MostRecentlyUsedList.Entries)
             {
-                yield return item.Path;
+                var item = await StorageApplicationPermissions.MostRecentlyUsedList.GetItemAsync(entry.Token, AccessCacheOptions.FastLocationsOnly);
+                if (parentPath != item.Path && item.Path.StartsWith(parentPath))
+                {
+                    yield return item.Path;
+                }
             }
         }
     }
@@ -437,22 +440,6 @@ public sealed class SourceStorageItemsRepository
             try
             {
                 var tokenStorageItem = await GetItemAsync(tokenEntry.Token);
-
-                // TODO: Ignoreに登録した後にトークンに対応するフォルダ名が変更された場合にIgnore判定から漏れる可能性に対応
-
-                // 既に破棄がリクエストされていた場合は、親ディレクトリ方向で利用できるフォルダがあれば
-                // そちらのフォルダのアクセス権を使ってストレージアイテムを取得する
-                if (tokenStorageItem != null && IsIgnoredPathExact(tokenStorageItem.Path))
-                {
-                    var otherEntry = GetAvairableTokensFromPath(path).FirstOrDefault();
-                    if (otherEntry == null)
-                    {
-                        throw new ArgumentException("path is already ignored, can not be used. >>> " + path);
-                    }
-
-                    tokenStorageItem = await GetItemAsync(otherEntry.Token);
-                }
-
                 if (tokenStorageItem?.Path == path)
                 {
                     return tokenStorageItem;
@@ -482,59 +469,6 @@ public sealed class SourceStorageItemsRepository
 
         return null;
     }
-
-    #region Ignore Process
-
-    public void AddIgnoreToken(string path)
-    {
-        if (_ignoreStorageItemRepository.IsIgnoredPath(path) is false)
-        {
-            _ignoreStorageItemRepository.CreateItem(new() { Path = path });
-        }
-    }
-
-    public bool IsIgnoredPath(string path)
-    {
-        var avairableTokens = GetAvairableTokensFromPath(path);
-        return avairableTokens.Any(x => path.StartsWith(x.Path)) is false;
-    }
-
-    public bool IsIgnoredPathExact(string path)
-    {
-        return _ignoreStorageItemRepository.IsIgnoredPathExact(path);
-    }
-
-    private IEnumerable<TokenToPathEntry> GetAvairableTokensFromPath(string path)
-    {
-        return _tokenToPathRepository.FindTokenToPathAll(path).Where(x => _ignoreStorageItemRepository.IsIgnoredPathExact(x.Path) is false);
-    }
-
-    public bool HasIgnorePath()
-    {
-        return _ignoreStorageItemRepository.Any();
-    }
-
-    public bool TryPeek(out string path)
-    {
-        if (_ignoreStorageItemRepository.TryPeek(out var entry))
-        {
-            path = entry.Path;
-            return true;
-        }
-        else
-        {
-            path = null;
-            return false;
-        }
-    }
-
-    public void DeleteIgnorePath(string path)
-    {
-        _ignoreStorageItemRepository.DeleteItem(path);
-
-    }
-
-    #endregion
 
     public void RemoveFolder(string token)
     {
@@ -570,8 +504,6 @@ public sealed class SourceStorageItemsRepository
             ct.ThrowIfCancellationRequested();
             var storageItem = await StorageApplicationPermissions.FutureAccessList.GetItemAsync(item.Token);
 
-            if (IsIgnoredPathExact(storageItem.Path)) { continue; }
-
             yield return (storageItem, item.Token, item.Metadata);
         }
 #else
@@ -600,8 +532,6 @@ public sealed class SourceStorageItemsRepository
 
             if (storageItem is not null)
             {
-                if (IsIgnoredPathExact(storageItem.Path)) { continue; }
-
                 yield return (storageItem, item.Token, item.Metadata);
             }
         }
@@ -615,7 +545,7 @@ public sealed class SourceStorageItemsRepository
     public IEnumerable<string> GetParsistantItemsFromCache()
     {
         return _tokenToPathRepository.ReadAllItems()
-            .Where(x => x.TokenListType == TokenListType.FutureAccessList && !IsIgnoredPathExact(x.Path)).Select(x => x.Path);
+            .Where(x => x.TokenListType == TokenListType.FutureAccessList).Select(x => x.Path);
     }
 
     public async IAsyncEnumerable<IStorageItem> SearchAsync(string keyword, [EnumeratorCancellation] CancellationToken ct)

--- a/TsubameViewer/App.xaml.cs
+++ b/TsubameViewer/App.xaml.cs
@@ -153,11 +153,11 @@ sealed partial class App : Application
 
         container.Register<SecondaryTileMaintenance>();
         container.Register<RemoveSourceStorageItemWhenPathIsEmpty>();
-        container.Register<CacheDeletionWhenSourceStorageItemIgnored>();
+        container.Register<CacheDeletionWhenSourceStorageItemIgnored>(Reuse.Singleton);
         container.Register<EnsureFavoriteAlbam>();
         container.RegisterMapping<ILaunchTimeMaintenanceAsync, SecondaryTileMaintenance>(ifAlreadyRegistered: IfAlreadyRegistered.AppendNotKeyed);
         container.RegisterMapping<ILaunchTimeMaintenanceAsync, RemoveSourceStorageItemWhenPathIsEmpty>(ifAlreadyRegistered: IfAlreadyRegistered.AppendNotKeyed);
-        container.RegisterMapping<ILaunchTimeMaintenance, CacheDeletionWhenSourceStorageItemIgnored>(ifAlreadyRegistered: IfAlreadyRegistered.AppendNotKeyed);
+        container.RegisterMapping<ILaunchTimeMaintenanceAsync, CacheDeletionWhenSourceStorageItemIgnored>(ifAlreadyRegistered: IfAlreadyRegistered.AppendNotKeyed);
         container.RegisterMapping<ILaunchTimeMaintenance, EnsureFavoriteAlbam>(ifAlreadyRegistered: IfAlreadyRegistered.AppendNotKeyed);
         
         container.Register<ILaunchTimeMaintenance, RecentlyAccessRepository>(ifAlreadyRegistered: IfAlreadyRegistered.AppendNotKeyed);

--- a/TsubameViewer/Contracts/Notification/InAppNotificationRequestMessage.cs
+++ b/TsubameViewer/Contracts/Notification/InAppNotificationRequestMessage.cs
@@ -6,21 +6,19 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace TsubameViewer.Contracts.Notification
+namespace TsubameViewer.Contracts.Notification;
+
+public sealed class InAppNotificationRequestMessage : ValueChangedMessage<object>
 {
-    public sealed class InAppNotificationRequestMessage : ValueChangedMessage<object>
+    public InAppNotificationRequestMessage(object value) : base(value)
     {
-        public InAppNotificationRequestMessage(object value) : base(value)
-        {
-        }
     }
+}
 
-    public static class InAppNotificationRequestMessageExtensions
+public static class InAppNotificationRequestMessageExtensions
+{
+    public static void SendShowTextNotificationMessage(this IMessenger messenger, string content)
     {
-        public static void SendShowTextNotificationMessage(this IMessenger messenger, string content)
-        {
-            messenger.Send(new InAppNotificationRequestMessage(content));
-        }
+        messenger.Send(new InAppNotificationRequestMessage(content));
     }
-
 }

--- a/TsubameViewer/Locales/en-US.txt
+++ b/TsubameViewer/Locales/en-US.txt
@@ -40,7 +40,7 @@ RefreshAfterCodecExtensionInstalled = Please refresh the display after installin
 FileDeleteFailed = File deletion failed \ n {0}
 FolderDeleteFailed = Failed to delete the folder \ n {0}
 ThumbnailImageChanged = Change thumbnail image
-
+Notification_SourceStorageItemNotFound = The specified path has been unregistered
 
 #### Dialog
 DoNotDisplayFromNextTime = Do not display from next time

--- a/TsubameViewer/Locales/ja-JP.txt
+++ b/TsubameViewer/Locales/ja-JP.txt
@@ -40,7 +40,7 @@ RefreshAfterCodecExtensionInstalled = 拡張機能をインストールしたら
 FileDeleteFailed = ファイル削除に失敗しました\n{0}
 FolderDeleteFailed = フォルダ削除に失敗しました\n{0}
 ThumbnailImageChanged = サムネイル画像を変更
-
+Notification_SourceStorageItemNotFound = 指定されたパスは登録解除済みです
 
 #### Dialog
 DoNotDisplayFromNextTime = 次回から表示しない

--- a/TsubameViewer/Locales/zh-CHS.txt
+++ b/TsubameViewer/Locales/zh-CHS.txt
@@ -40,7 +40,7 @@ RefreshAfterCodecExtensionInstalled = 安装扩展后请刷新显示
 FileDeleteFailed = 文件删除失败 \n {0}
 FolderDeleteFailed = 文件夹删除失败\n{0}
 ThumbnailImageChanged = 更改封面
-
+Notification_SourceStorageItemNotFound = 指定路径已注销
 
 #### Dialog
 DoNotDisplayFromNextTime = 下次不再显示

--- a/TsubameViewer/ViewModels/FolderListupPageViewModel.cs
+++ b/TsubameViewer/ViewModels/FolderListupPageViewModel.cs
@@ -333,11 +333,7 @@ public sealed class FolderListupPageViewModel : NavigationAwareViewModelBase
             {
                 (var newPath, var pageName) = PageNavigationConstants.ParseStorageItemId(Uri.UnescapeDataString(path));
 
-                if (_sourceStorageItemsRepository.IsIgnoredPath(newPath))
-                {
-                    throw new InvalidOperationException();
-                }
-                else if (await IsRequireUpdateAsync(newPath, pageName, ct))
+                if (await IsRequireUpdateAsync(newPath, pageName, ct))
                 {
                     await ResetContent(newPath, pageName, ct);
                 }

--- a/TsubameViewer/ViewModels/ImageListupPageViewModel.cs
+++ b/TsubameViewer/ViewModels/ImageListupPageViewModel.cs
@@ -35,6 +35,7 @@ using TsubameViewer.Views;
 using Windows.Storage;
 using Windows.UI.Xaml.Navigation;
 using CommunityToolkit.Diagnostics;
+using TsubameViewer.Contracts.Notification;
 
 namespace TsubameViewer.ViewModels;
 
@@ -352,6 +353,8 @@ public sealed class ImageListupPageViewModel : NavigationAwareViewModelBase
                 }
                 else
                 {
+                    _sourceStorageItemsRepository.ThrowIfPathIsUnauthorizedAccess(newPath);
+
                     foreach (var itemVM in ImageFileItems)
                     {
                         itemVM.RestoreThumbnailLoadingTask(ct);

--- a/TsubameViewer/ViewModels/PageNavigation/BusyWallRequestMessage.cs
+++ b/TsubameViewer/ViewModels/PageNavigation/BusyWallRequestMessage.cs
@@ -12,12 +12,19 @@ namespace TsubameViewer.ViewModels.PageNavigation
 {
     public class BusyWallStartRequestMessageData
     {
+        public bool IsCanCancel { get; set; }
     }
 
     public sealed class BusyWallStartRequestMessage : ValueChangedMessage<BusyWallStartRequestMessageData>
     {
-        public BusyWallStartRequestMessage() : base(new BusyWallStartRequestMessageData())
+        public BusyWallStartRequestMessage() : base(new BusyWallStartRequestMessageData() { IsCanCancel = true })
         {
+
+        }
+
+        public BusyWallStartRequestMessage(bool isCanCancel) : base(new BusyWallStartRequestMessageData() { IsCanCancel = isCanCancel })
+        {
+            
         }
     }
 

--- a/TsubameViewer/ViewModels/PrimaryWindowCoreLayoutViewModel.cs
+++ b/TsubameViewer/ViewModels/PrimaryWindowCoreLayoutViewModel.cs
@@ -107,7 +107,10 @@ public sealed class PrimaryWindowCoreLayoutViewModel
 
     void IRecipient<SourceStorageItemRemovedMessage>.Receive(SourceStorageItemRemovedMessage message)
     {
-        RefreshFolderSubItems();
+        _scheduler.Schedule(() => 
+        {
+            RefreshFolderSubItems();
+        });
     }
 
     void IRecipient<SourceStorageItemAddedMessage>.Receive(SourceStorageItemAddedMessage message)

--- a/TsubameViewer/ViewModels/SourceStorageItemsPageViewModel.cs
+++ b/TsubameViewer/ViewModels/SourceStorageItemsPageViewModel.cs
@@ -287,11 +287,17 @@ namespace TsubameViewer.ViewModels
 
             _messenger.Register<AccessRemovedValueChangedMessage>(this, (r, m) => 
             {
-                RemoveItem(m.Value);
+                _scheduler.Schedule(() =>
+                {
+                    RemoveItem(m.Value);
+                });
             });
             _messenger.Register<SourceStorageItemIgnoringRequestMessage>(this, (r, m) => 
             {
-                RemoveItem(m.Path);
+                _scheduler.Schedule(() =>
+                {
+                    RemoveItem(m.Path);
+                });
             });
 
             _messenger.Register<SourceStorageItemsRepository.SourceStorageItemRemovedMessage>(this, (r, m) =>

--- a/TsubameViewer/ViewModels/SourceStorageItemsPageViewModel.cs
+++ b/TsubameViewer/ViewModels/SourceStorageItemsPageViewModel.cs
@@ -20,6 +20,8 @@ using TsubameViewer.ViewModels.PageNavigation;
 using TsubameViewer.ViewModels.PageNavigation.Commands;
 using TsubameViewer.ViewModels.SourceFolders.Commands;
 using Windows.UI.Xaml.Navigation;
+using System.Reactive.Concurrency;
+using TsubameViewer.Core.Models.Maintenance;
 
 namespace TsubameViewer.ViewModels
 {
@@ -33,6 +35,7 @@ namespace TsubameViewer.ViewModels
         private readonly LocalBookmarkRepository _bookmarkManager;
         private readonly AlbamRepository _albamRepository;
         private readonly ThumbnailImageManager _thumbnailManager;
+        private readonly IScheduler _scheduler;
         private readonly IMessenger _messenger;
         private readonly SourceStorageItemsRepository _sourceStorageItemsRepository;
         private readonly LastIntractItemRepository _folderLastIntractItemManager;
@@ -57,6 +60,7 @@ namespace TsubameViewer.ViewModels
 
         bool _foldersInitialized = false;
         public SourceStorageItemsPageViewModel(
+            IScheduler scheduler,
             IMessenger messenger,
             FolderListingSettings folderListingSettings,
             LocalBookmarkRepository bookmarkManager,
@@ -95,6 +99,7 @@ namespace TsubameViewer.ViewModels
             _bookmarkManager = bookmarkManager;
             _albamRepository = albamRepository;
             _thumbnailManager = thumbnailManager;
+            _scheduler = scheduler;
             _messenger = messenger;
 
             Groups = new[]
@@ -138,11 +143,6 @@ namespace TsubameViewer.ViewModels
                     Folders.Add(new StorageItemViewModel("AddNewFolder".Translate(), Core.Models.StorageItemTypes.AddFolder));
                     await foreach (var item in _sourceStorageItemsRepository.GetParsistantItems())
                     {
-                        if (_sourceStorageItemsRepository.IsIgnoredPathExact(item.item.Path))
-                        {
-                            continue;
-                        }
-
                         var storageItemImageSource = new StorageItemImageSource(item.item);
                         if (storageItemImageSource.ItemTypes == Core.Models.StorageItemTypes.Folder)
                         {
@@ -157,28 +157,16 @@ namespace TsubameViewer.ViewModels
                 else
                 {
                     var lastIntaractItemPath = _folderLastIntractItemManager.GetLastIntractItemName(nameof(SourceStorageItemsPageViewModel));
-                    List<StorageItemViewModel> ignoredItems = new List<StorageItemViewModel>();
                     foreach (var folderItem in Folders)
                     {
                         if (folderItem.Path == null) { continue; }
 
-                        if (_sourceStorageItemsRepository.IsIgnoredPathExact(folderItem.Path))
-                        {
-                            ignoredItems.Add(folderItem);
-                            continue;
-                        }
                         folderItem.UpdateLastReadPosition();
                         if (folderItem.Name == lastIntaractItemPath)
                         {
                             folderItem.ThumbnailChanged();
                             folderItem.Initialize(ct);
                         }
-                    }
-
-                    foreach (var ignoreItem in ignoredItems)
-                    {
-                        ignoreItem.Dispose();
-                        Folders.Remove(ignoreItem);
                     }
 
                     ct.ThrowIfCancellationRequested();
@@ -204,11 +192,6 @@ namespace TsubameViewer.ViewModels
                     RecentlyItems.Clear();
                     foreach (var item in recentlyAccessItems)
                     {
-                        if (_sourceStorageItemsRepository.IsIgnoredPathExact(item.Path))
-                        {
-                            continue;
-                        }
-
                         try
                         {
                             var itemVM = await ToStorageItemViewModel(item);
@@ -302,14 +285,21 @@ namespace TsubameViewer.ViewModels
                 }                
             });
 
-            _messenger.Register<SourceStorageItemIgnoringRequestMessage>(this, (r, m) => 
+            _messenger.Register<AccessRemovedValueChangedMessage>(this, (r, m) => 
             {
                 RemoveItem(m.Value);
+            });
+            _messenger.Register<SourceStorageItemIgnoringRequestMessage>(this, (r, m) => 
+            {
+                RemoveItem(m.Path);
             });
 
             _messenger.Register<SourceStorageItemsRepository.SourceStorageItemRemovedMessage>(this, (r, m) =>
             {
-                RemoveItem(m.Value.Path);
+                _scheduler.Schedule(() => 
+                {
+                    RemoveItem(m.Value.Path);
+                });
             });
         }
 

--- a/TsubameViewer/Views/PrimaryWindowCoreLayout.xaml
+++ b/TsubameViewer/Views/PrimaryWindowCoreLayout.xaml
@@ -226,6 +226,7 @@
                 HorizontalAlignment="Center"
                 Style="{ThemeResource AccentButtonStyle}"
                 AccessKey="C"
+                x:Name="BusyWallCancelButton"
                 />
 
 
@@ -308,6 +309,24 @@
             <Setter Target="BusyWall.Visibility" Value="Visible" />
             <Setter Target="BusyWall.IsHitTestVisible" Value="True" />
             <Setter Target="BusyWall_ProgressRing.IsActive" Value="True" />
+          </VisualState.Setters>
+        </VisualState>
+        <VisualState x:Name="VS_ShowBusyWall_WithoutCancel">
+          <VisualState.Storyboard>
+            <Storyboard>
+              <DoubleAnimation Duration="0:0:0.175"
+                               BeginTime="{x:Bind _BusyWallDisplayDelayTime}"
+                               To="1.0"
+                               Storyboard.TargetName="BusyWall"
+                               Storyboard.TargetProperty="Opacity"
+                               />
+            </Storyboard>
+          </VisualState.Storyboard>
+          <VisualState.Setters>
+            <Setter Target="BusyWall.Visibility" Value="Visible" />
+            <Setter Target="BusyWall.IsHitTestVisible" Value="True" />
+            <Setter Target="BusyWall_ProgressRing.IsActive" Value="True" />
+            <Setter Target="BusyWallCancelButton.Visibility" Value="Collapsed" />
           </VisualState.Setters>
         </VisualState>
       </VisualStateGroup>

--- a/TsubameViewer/Views/PrimaryWindowCoreLayout.xaml.cs
+++ b/TsubameViewer/Views/PrimaryWindowCoreLayout.xaml.cs
@@ -973,10 +973,18 @@ public sealed partial class PrimaryWindowCoreLayout : Page
 
     private void InitializeBusyWorkUI()
     {
-        _messenger.Register<BusyWallStartRequestMessage>(this, (r, m) =>
+        var dispatcherQueue = DispatcherQueue.GetForCurrentThread();
+        _messenger.Register<BusyWallStartRequestMessage>(this, async (r, m) =>
         {
             _AnimationCancelTimer.Start();
-            VisualStateManager.GoToState(this, VS_ShowBusyWall.Name, true);
+            if (m.Value.IsCanCancel)
+            {
+                VisualStateManager.GoToState(this, VS_ShowBusyWall.Name, true);
+            }
+            else
+            {
+                VisualStateManager.GoToState(this, VS_ShowBusyWall_WithoutCancel.Name, true);
+            }
         });
 
         _messenger.Register<BusyWallExitRequestMessage>(this, (r, m) =>

--- a/TsubameViewer/Views/PrimaryWindowCoreLayout.xaml.cs
+++ b/TsubameViewer/Views/PrimaryWindowCoreLayout.xaml.cs
@@ -37,6 +37,7 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media.Animation;
 using Windows.UI.Xaml.Navigation;
 using TsubameViewer.Services;
+using System.IO;
 
 namespace TsubameViewer.Views;
 
@@ -205,13 +206,13 @@ public sealed partial class PrimaryWindowCoreLayout : Page
     private void InitializeNavigation()
     {
         async Task<INavigationResult> NavigationAsyncInternal(NavigationRequestMessage m)
-        {
-            using var lockReleaser = await _navigationLock.LockAsync(CancellationToken.None);
-
-            var (currentNavParam, prevNavParam) = GetNavigationParametersSet();
-
+        {            
             try
             {
+                using var lockReleaser = await _navigationLock.LockAsync(CancellationToken.None);
+
+                var (currentNavParam, prevNavParam) = GetNavigationParametersSet();
+
                 if (m.IsForgetNavigaiton)
                 {
                     _isForgetNavigationRequested = true;
@@ -221,11 +222,20 @@ public sealed partial class PrimaryWindowCoreLayout : Page
                 parameters.SetNavigationMode(NavigationMode.New);
                 return await NavigateAsync(m.PageName, parameters, m.IsForgetNavigaiton is false);
             }
-            catch
+            catch (OperationCanceledException)
             {
-                SetCurrentNavigationParameters(prevNavParam);
-                SetCurrentNavigationParameters(currentNavParam);
+                // ロールバックして前のページを表示
+                await HandleBackRequestAsync();
                 _isForgetNavigationRequested = false;
+                throw;
+            }
+            catch (Exception ex) when (ex is FileNotFoundException or UnauthorizedAccessException)
+            {
+                // ファイルにアクセス出来ない例外の場合はホームページへ遷移
+                var navigationParameters = new NavigationParameters();
+                navigationParameters.SetNavigationMode(NavigationMode.New);
+                await NavigateAsync(HomePageName, navigationParameters, false);
+                _messenger.SendShowTextNotificationMessage("Notification_SourceStorageItemNotFound".Translate());
                 throw;
             }
         }
@@ -474,42 +484,26 @@ public sealed partial class PrimaryWindowCoreLayout : Page
         var options = new FrameNavigationOptions() { IsNavigationStackEnabled = isNavigationStackEnabled, TransitionInfoOverride = PageTransitionHelper.MakeNavigationTransitionInfoFromPageName(pageName) };
         var result = ContentFrame.Navigate(viewType, parameters, options.TransitionInfoOverride);
 
-        if (result)
+        if (result is false)
         {
-            var currentPage = ContentFrame.Content as Page;
-            return await HandleViewModelNavigation(prevPage?.DataContext as INavigationAware, currentPage?.DataContext as INavigationAware, parameters);
+            throw new InvalidOperationException($"Failed ContentFrame navigate to {pageName}.");
         }
-        else
-        {
-            return new NavigationResult() { IsSuccess = false, Exception = new Exception("failed navigation with unknown error. also check Xaml.") };
-        }
+
+        var currentPage = ContentFrame.Content as Page;
+        return await HandleViewModelNavigation(prevPage?.DataContext as INavigationAware, currentPage?.DataContext as INavigationAware, parameters);        
     }
 
     private async Task<NavigationResult> HandleViewModelNavigation(INavigationAware fromPageVM, INavigationAware toPageVM, INavigationParameters parameters)
     {
-        try
+        if (fromPageVM != null)
         {
-            if (fromPageVM != null)
-            {
-                fromPageVM.OnNavigatedFrom(parameters);
-            }
-        }
-        catch (Exception ex)
-        {
-            return new NavigationResult() { IsSuccess = false, Exception = ex };
+            fromPageVM.OnNavigatedFrom(parameters);
         }
 
-        try
+        if (toPageVM != null)
         {
-            if (toPageVM != null)
-            {
-                toPageVM.OnNavigatedTo(parameters);
-                await toPageVM.OnNavigatedToAsync(parameters);
-            }
-        }
-        catch (Exception ex)
-        {
-            return new NavigationResult() { IsSuccess = false, Exception = ex };
+            toPageVM.OnNavigatedTo(parameters);
+            await toPageVM.OnNavigatedToAsync(parameters);
         }
 
         return new NavigationResult() { IsSuccess = true };
@@ -603,8 +597,7 @@ public sealed partial class PrimaryWindowCoreLayout : Page
         catch
         {
             Debug.WriteLine("[NavigationRestore] failed restore current page. ");
-
-            await ResetNavigationAsync();
+            throw;
         }            
     }
 
@@ -765,6 +758,7 @@ public sealed partial class PrimaryWindowCoreLayout : Page
                         {
                             _currentNavigationParameters = lastNavigationParametersSet.Current;
                             _prevNavigationParameters = lastNavigationParametersSet.Prev;
+                            throw;
                         }
                     }
                     else
@@ -830,6 +824,7 @@ public sealed partial class PrimaryWindowCoreLayout : Page
             {
                 _currentNavigationParameters = lastNavigationParametersSet.Current;
                 _prevNavigationParameters = lastNavigationParametersSet.Prev;
+                throw;
             }
         }
     }


### PR DESCRIPTION
これまでは登録フォルダを削除した時に無効化フォルダとして登録してアプリ終了時等にバックグラウンドで削除動作を行わせる仕組みでしたが、より単純で確実な動作を実現するために登録フォルダを削除する設定ページ上でUI操作を阻害した状態で削除動作を行うようにしました。

仮に削除中にアプリを終了した場合は次回起動時に削除動作を続行するようになっています。（メンテナンス処理を通じて実現）

これまでD&Dでアプリに投げられたファイル（最近使ったアイテム）は削除対象の登録フォルダに含まれていてもスキップしていましたが、今回の修正によって最近使ったアイテムを含めて削除するように動作変更を行いました。